### PR TITLE
In Makevars, remove unused settings for CC and CCX.

### DIFF
--- a/r-package/grf/bindings/Makevars
+++ b/r-package/grf/bindings/Makevars
@@ -1,9 +1,6 @@
 ## Use c++11
 CXX_STD = CXX11
 
-CC=/usr/local/bin/gcc-4.9
-CXX=/usr/local/bin/g++-4.9
-
 PKG_CXXFLAGS = -I. -Isrc -Ithird_party -DR_BUILD
 
 SOURCES = $(wildcard *.cpp */*.cpp */*/*.cpp */*/*/*.cpp)


### PR DESCRIPTION
These only make sense in a local context, and are not used when building the R package.