### PR TITLE
Ensure we always default mtry to sqrt(p) + 20.

### DIFF
--- a/r-package/grf/R/instrumental_forest.R
+++ b/r-package/grf/R/instrumental_forest.R
@@ -41,7 +41,7 @@
 #'
 #' @return A trained instrumental forest object.
 #' @export
-instrumental_forest <- function(X, Y, W, Z, sample.fraction = 0.5, mtry = ceiling(2*ncol(X)/3), 
+instrumental_forest <- function(X, Y, W, Z, sample.fraction = 0.5, mtry = NULL,
                                 num.trees = 2000, num.threads = NULL, min.node.size = NULL, honesty = TRUE,
                                 ci.group.size = 2, precompute.nuisance = TRUE, split.regularization = 0,
                                 alpha = 0.05, lambda = 0.0, downweight.penalty = FALSE, seed = NULL) {

--- a/r-package/grf/R/quantile_forest.R
+++ b/r-package/grf/R/quantile_forest.R
@@ -53,7 +53,7 @@
 #' 
 #' @export
 quantile_forest <- function(X, Y, quantiles = c(0.1, 0.5, 0.9), regression.splitting = FALSE,
-                            sample.fraction = 0.5, mtry = ceiling(2*ncol(X)/3), num.trees = 2000,
+                            sample.fraction = 0.5, mtry = NULL, num.trees = 2000,
                             num.threads = NULL, min.node.size = NULL, seed = NULL, alpha = 0.05,
                             honesty = TRUE) {
     

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -47,7 +47,7 @@
 #' r.pred = predict(r.forest, X.test, estimate.variance = TRUE)
 #'
 #' @export
-regression_forest <- function(X, Y, sample.fraction = 0.5, mtry = ceiling(2*ncol(X)/3), 
+regression_forest <- function(X, Y, sample.fraction = 0.5, mtry = NULL, 
                               num.trees = 2000, num.threads = NULL, min.node.size = NULL,
                               honesty = TRUE, ci.group.size = 2, alpha = 0.05, lambda = 0.0,
                               downweight.penalty = FALSE, seed = NULL) {


### PR DESCRIPTION
The old default of 2/3 * p was still being used in places, which was causing poor performance with even moderately large p.