### PR TITLE
Add a tune.parameters option to regression_train.

### DIFF
--- a/core/src/forest/ForestOptions.cpp
+++ b/core/src/forest/ForestOptions.cpp
@@ -83,3 +83,11 @@ uint ForestOptions::get_num_threads() const {
 uint ForestOptions::get_random_seed() const {
   return random_seed;
 }
+
+uint ForestOptions::get_min_node_size() const {
+  return tree_options.get_min_node_size();
+}
+
+void ForestOptions::set_min_node_size(uint min_node_size) {
+  return tree_options.set_min_node_size(min_node_size);
+}

--- a/core/src/forest/ForestOptions.h
+++ b/core/src/forest/ForestOptions.h
@@ -45,6 +45,13 @@ public:
   uint get_num_threads() const;
   uint get_random_seed() const;
 
+
+  uint get_min_node_size() const;
+
+  // TODO(jtibs): check the C++ best practices on mutability, and perhaps
+  // replace this with an immutable factory method 'with_min_node_size'.
+  void set_min_node_size(uint min_node_size);
+
 private:
   uint num_trees;
   uint ci_group_size;

--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -39,17 +39,17 @@ ForestPredictor::ForestPredictor(uint num_threads,
                       : num_threads;
 }
 
-std::vector<Prediction> ForestPredictor::predict(const Forest& forest, Data* data) {
+std::vector<Prediction> ForestPredictor::predict(const Forest& forest, Data* data) const {
   return predict(forest, data, false);
 }
 
-std::vector<Prediction> ForestPredictor::predict_oob(const Forest& forest, Data* data) {
+std::vector<Prediction> ForestPredictor::predict_oob(const Forest& forest, Data* data) const {
   return predict(forest, data, true);
 }
 
 std::vector<Prediction> ForestPredictor::predict(const Forest& forest,
                                                  Data* data,
-                                                 bool oob_prediction) {
+                                                 bool oob_prediction) const {
   std::vector<std::vector<size_t>> leaf_nodes_by_tree = find_leaf_nodes(forest, data, oob_prediction);
   std::vector<std::vector<bool>> trees_by_sample = oob_prediction
           ? get_trees_by_sample(forest, data)
@@ -58,7 +58,7 @@ std::vector<Prediction> ForestPredictor::predict(const Forest& forest,
 }
 
 std::vector<std::vector<bool>> ForestPredictor::get_trees_by_sample(const Forest &forest,
-                                                                    Data *data) {
+                                                                    Data *data) const {
   size_t num_trees = forest.get_trees().size();
   size_t num_samples = data->get_num_rows();
 
@@ -75,7 +75,7 @@ std::vector<std::vector<bool>> ForestPredictor::get_trees_by_sample(const Forest
 std::vector<std::vector<size_t>> ForestPredictor::find_leaf_nodes(
     const Forest& forest,
     Data* data,
-    bool oob_prediction) {
+    bool oob_prediction) const {
   size_t num_trees = forest.get_trees().size();
 
   std::vector<std::vector<size_t>> leaf_nodes_by_tree;
@@ -116,7 +116,7 @@ std::vector<std::vector<size_t>> ForestPredictor::find_batch(
     size_t num_trees,
     const Forest &forest,
     Data *prediction_data,
-    bool oob_prediction) {
+    bool oob_prediction) const {
   std::vector<std::vector<size_t>> all_leaf_nodes(num_trees);
   for (size_t i = 0; i < num_trees; ++i) {
     std::shared_ptr<Tree> tree = forest.get_trees()[start + i];

--- a/core/src/forest/ForestPredictor.h
+++ b/core/src/forest/ForestPredictor.h
@@ -42,28 +42,28 @@ public:
                   uint ci_group_size,
                   std::shared_ptr<OptimizedPredictionStrategy> strategy);
 
-  std::vector<Prediction> predict(const Forest& forest, Data* prediction_data);
-  std::vector<Prediction> predict_oob(const Forest& forest, Data* original_data);
+  std::vector<Prediction> predict(const Forest& forest, Data* prediction_data) const;
+  std::vector<Prediction> predict_oob(const Forest& forest, Data* original_data) const;
 
 private:
   std::vector<Prediction> predict(const Forest& forest,
                                   Data* prediction_data,
-                                  bool oob_prediction);
+                                  bool oob_prediction) const;
 
   std::vector<std::vector<bool>> get_trees_by_sample(const Forest &forest,
-                                                     Data *data);
+                                                     Data *data) const;
 
   std::vector<std::vector<size_t>> find_leaf_nodes(
       const Forest &forest,
       Data *data,
-      bool oob_prediction);
+      bool oob_prediction) const;
 
   std::vector<std::vector<size_t>> find_batch(
       size_t start,
       size_t num_trees,
       const Forest &forest,
       Data *prediction_data,
-      bool oob_prediction);
+      bool oob_prediction) const;
 
 
 private:

--- a/core/src/tree/TreeOptions.cpp
+++ b/core/src/tree/TreeOptions.cpp
@@ -36,3 +36,7 @@ uint TreeOptions::get_min_node_size() const  {
 bool TreeOptions::get_honesty() const {
   return honesty;
 }
+
+void TreeOptions::set_min_node_size(uint min_node_size) {
+  this->min_node_size = min_node_size;
+}

--- a/core/src/tuning/ParameterTuner.cpp
+++ b/core/src/tuning/ParameterTuner.cpp
@@ -1,0 +1,63 @@
+/*-------------------------------------------------------------------------------
+  This file is part of generalized-random-forest.
+
+  grf is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  grf is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with grf. If not, see <http://www.gnu.org/licenses/>.
+ #-------------------------------------------------------------------------------*/
+
+#include <limits.h>
+#include "ParameterTuner.h"
+
+ParameterTuner::ParameterTuner(const ForestTrainer& trainer,
+                               const ForestPredictor& predictor,
+                               uint outcome_index):
+    trainer(trainer), predictor(predictor), outcome_index(outcome_index) {}
+
+uint ParameterTuner::tune_min_node_size(Data* data,
+                                        ForestOptions& options) {
+  uint upper_bound = (uint) (data->get_num_rows() * options.get_sample_fraction()) / 4;
+
+  uint min_node_size = 10;
+  double best_mse = std::numeric_limits<double>::max();
+  uint best_min_node_size = NAN;
+
+  while (min_node_size < upper_bound) {
+    options.set_min_node_size(min_node_size);
+
+    const Forest forest = trainer.train(data, options);
+    std::vector<Prediction> predictions = predictor.predict_oob(forest, data);
+    double mse = calculate_mse(predictions, data);
+
+    if (mse < best_mse) {
+      best_mse = mse;
+      best_min_node_size = min_node_size;
+    }
+    min_node_size *= 2;
+  }
+
+  return best_min_node_size;
+}
+
+double ParameterTuner::calculate_mse(const std::vector<Prediction>& predictions,
+                                     Data* data) {
+  double mean_squared_error = 0;
+  for (size_t i = 0; i < predictions.size(); ++i) {
+    double actual_outcome = data->get(i, outcome_index);
+    const Prediction& prediction = predictions[i];
+    double predicted_outcome = prediction.get_predictions().at(0);
+
+    double difference = (actual_outcome - predicted_outcome);
+    mean_squared_error += difference * difference;
+  }
+  return mean_squared_error / predictions.size();
+}

--- a/core/src/tuning/ParameterTuner.h
+++ b/core/src/tuning/ParameterTuner.h
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------
-  This file is part of generalized random forest (grf).
+  This file is part of generalized-random-forest.
 
   grf is free software: you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -15,32 +15,31 @@
   along with grf. If not, see <http://www.gnu.org/licenses/>.
  #-------------------------------------------------------------------------------*/
 
-#ifndef GRF_TREEOPTIONS_H
-#define GRF_TREEOPTIONS_H
-
-
-#include <set>
-#include <string>
-#include <vector>
+#ifndef GRF_PARAMETERTUNER_H
+#define GRF_PARAMETERTUNER_H
 
 #include "commons/globals.h"
+#include "forest/ForestPredictor.h"
+#include "forest/ForestTrainer.h"
 
-class TreeOptions {
+class ParameterTuner {
+
 public:
-  TreeOptions(uint mtry,
-              uint min_node_size,
-              bool honesty);
-
-  uint get_mtry() const;
-  uint get_min_node_size() const;
-  bool get_honesty() const;
-
-  void set_min_node_size(uint min_node_size);
+  ParameterTuner(const ForestTrainer& trainer,
+                 const ForestPredictor& predictor,
+                 uint outcome_index);
+  uint tune_min_node_size(Data* data,
+                          ForestOptions &options);
 
 private:
-  uint mtry;
-  uint min_node_size;
-  bool honesty;
+  double calculate_mse(const std::vector<Prediction>& predictions,
+                       Data* data);
+
+  ForestTrainer trainer;
+  ForestPredictor predictor;
+  uint outcome_index;
 };
 
-#endif //GRF_TREEOPTIONS_H
+
+
+#endif //GRF_PARAMETERTUNER_H

--- a/core/test/tuning/ParameterTunerTest.cpp
+++ b/core/test/tuning/ParameterTunerTest.cpp
@@ -1,0 +1,45 @@
+/*-------------------------------------------------------------------------------
+  This file is part of generalized random forest (grf).
+
+  grf is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  grf is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with grf. If not, see <http://www.gnu.org/licenses/>.
+ #-------------------------------------------------------------------------------*/
+
+#include "commons/utility.h"
+#include "forest/ForestPredictor.h"
+#include "forest/ForestPredictors.h"
+#include "forest/ForestTrainer.h"
+#include "forest/ForestTrainers.h"
+#include "tuning/ParameterTuner.h"
+#include "utilities/ForestTestUtilities.h"
+
+#include "catch.hpp"
+
+
+TEST_CASE("tuning selects a reasonable min node size", "[tuning, forest]") {
+  uint outcome_index = 10;
+  double alpha = 0.0;
+
+  ForestTrainer trainer = ForestTrainers::regression_trainer(outcome_index, alpha);
+  ForestPredictor predictor = ForestPredictors::regression_predictor(4, 1);
+  ParameterTuner tuner(trainer, predictor, outcome_index);
+
+  Data* data = load_data("test/forest/resources/gaussian_data.csv");
+  ForestOptions options = ForestTestUtilities::default_options();
+
+  uint upper_bound = (uint) (data->get_num_rows() * options.get_sample_fraction()) / 4;
+  uint min_node_size = tuner.tune_min_node_size(data, options);
+
+  REQUIRE(min_node_size > upper_bound / 2);
+  delete data;
+}

--- a/r-package/grf/R/RcppExports.R
+++ b/r-package/grf/R/RcppExports.R
@@ -45,8 +45,8 @@ quantile_predict_oob <- function(forest_object, quantiles, input_data, sparse_in
     .Call('_grf_quantile_predict_oob', PACKAGE = 'grf', forest_object, quantiles, input_data, sparse_input_data, variable_names, num_threads)
 }
 
-regression_train <- function(input_data, sparse_input_data, outcome_index, variable_names, mtry, num_trees, verbose, num_threads, min_node_size, sample_with_replacement, keep_inbag, sample_fraction, seed, honesty, ci_group_size, alpha, lambda, downweight_penalty) {
-    .Call('_grf_regression_train', PACKAGE = 'grf', input_data, sparse_input_data, outcome_index, variable_names, mtry, num_trees, verbose, num_threads, min_node_size, sample_with_replacement, keep_inbag, sample_fraction, seed, honesty, ci_group_size, alpha, lambda, downweight_penalty)
+regression_train <- function(input_data, sparse_input_data, outcome_index, variable_names, mtry, num_trees, verbose, num_threads, min_node_size, sample_with_replacement, keep_inbag, sample_fraction, seed, honesty, ci_group_size, alpha, lambda, downweight_penalty, tune_parameters) {
+    .Call('_grf_regression_train', PACKAGE = 'grf', input_data, sparse_input_data, outcome_index, variable_names, mtry, num_trees, verbose, num_threads, min_node_size, sample_with_replacement, keep_inbag, sample_fraction, seed, honesty, ci_group_size, alpha, lambda, downweight_penalty, tune_parameters)
 }
 
 regression_predict <- function(forest_object, input_data, sparse_input_data, variable_names, num_threads, ci_group_size) {

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -24,6 +24,7 @@
 #' @param lambda A tuning parameter to control the amount of split regularization (experimental).
 #' @param downweight.penalty Whether or not the regularization penalty should be downweighted (experimental).
 #' @param seed The seed for the C++ random number generator.
+#' @param tune.parameters Experimental option that allows for parameters like min.node.size to be automatically tuned.
 #'
 #' @return A trained regression forest object.
 #'
@@ -51,7 +52,7 @@
 regression_forest <- function(X, Y, sample.fraction = 0.5, mtry = NULL, 
                               num.trees = 2000, num.threads = NULL, min.node.size = NULL,
                               honesty = TRUE, ci.group.size = 2, alpha = 0.05, lambda = 0.0,
-                              downweight.penalty = FALSE, seed = NULL) {
+                              downweight.penalty = FALSE, seed = NULL, tune.parameters = FALSE) {
     
     validate_X(X)
     if(length(Y) != nrow(X)) { stop("Y has incorrect length.") }
@@ -69,10 +70,10 @@ regression_forest <- function(X, Y, sample.fraction = 0.5, mtry = NULL,
     data <- create_data_matrices(X, Y)
     variable.names <- c(colnames(X), "outcome")
     outcome.index <- ncol(X) + 1
-    
+
     forest <- regression_train(data$default, data$sparse, outcome.index, variable.names, mtry, num.trees,
         verbose, num.threads, min.node.size, sample.with.replacement, keep.inbag, sample.fraction,
-        seed, honesty, ci.group.size, alpha, lambda, downweight.penalty)
+        seed, honesty, ci.group.size, alpha, lambda, downweight.penalty, tune.parameters)
     
     forest[["ci.group.size"]] <- ci.group.size
     forest[["X.orig"]] <- X

--- a/r-package/grf/bindings/RegressionForestBindings.cpp
+++ b/r-package/grf/bindings/RegressionForestBindings.cpp
@@ -7,6 +7,7 @@
 #include "Eigen/Sparse"
 #include "forest/ForestPredictors.h"
 #include "forest/ForestTrainers.h"
+#include "tuning/ParameterTuner.h"
 #include "RcppUtilities.h"
 
 // [[Rcpp::export]]
@@ -27,7 +28,8 @@ Rcpp::List regression_train(Rcpp::NumericMatrix input_data,
                             unsigned int ci_group_size,
                             double alpha,
                             double lambda,
-                            bool downweight_penalty) {
+                            bool downweight_penalty,
+                            bool tune_parameters) {
   ForestTrainer trainer = lambda > 0
       ? ForestTrainers::regularized_regression_trainer(outcome_index - 1, lambda, downweight_penalty)
       : ForestTrainers::regression_trainer(outcome_index - 1, alpha);
@@ -36,9 +38,18 @@ Rcpp::List regression_train(Rcpp::NumericMatrix input_data,
   ForestOptions options(num_trees, ci_group_size, sample_fraction, mtry, min_node_size,
                         honesty, sample_with_replacement, num_threads, seed);
 
+  if (tune_parameters) {
+    ForestPredictor predictor = ForestPredictors::regression_predictor(num_threads, ci_group_size);
+    ParameterTuner tuner(trainer, predictor, outcome_index);
+    uint tuned_min_node_size = tuner.tune_min_node_size(data, options);
+    options.set_min_node_size(tuned_min_node_size);
+  }
+
   Forest forest = trainer.train(data, options);
 
   Rcpp::List result = RcppUtilities::create_forest_object(forest, data);
+  result.push_back(options.get_min_node_size(), "tuned.min.node.size");
+
   delete data;
   return result;
 }


### PR DESCRIPTION
Currently, the procedure just selects min node size through simple cross-validation.
We expect to make continual performance improvements to this tuning strategy.