### PR TITLE
Make sure to default the min node size to 10.

### DIFF
--- a/r-package/grf/R/input_utilities.R
+++ b/r-package/grf/R/input_utilities.R
@@ -35,7 +35,7 @@ validate_num_threads <- function(num.threads) {
 
 validate_min_node_size <- function(min.node.size) {
   if (is.null(min.node.size)) {
-    min.node.size <- 0
+    min.node.size <- 10
   } else if (!is.numeric(min.node.size) | min.node.size < 0) {
     stop("Error: Invalid value for min.node.size")
   }


### PR DESCRIPTION
Previously this default was specified in C++, but after the options code
was restructured, we're now providing the it in R.

Note that the default has also changed to 10, from 5 as it was in the C++ code.