### PR TITLE
Add functionality for overlap-weighted treatment effect.

### DIFF
--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -67,12 +67,12 @@ average_treatment_effect = function(forest,
   # W to be binary here.
   #
   
-  if (method == "overlap") {
+  if (target.sample == "overlap") {
     W.residual = forest$W.orig - forest$W.hat
     Y.residual = forest$Y.orig - forest$Y.hat
-    tau.ols = lm(Y.residual ~ W.residual + 0)
-    tau.est <- coef(summary(tau.ols))[1,1]
-    tau.se <- coef(summary(tau.ols))[1,2]
+    tau.ols = lm(Y.residual ~ W.residual)
+    tau.est <- coef(summary(tau.ols))[2,1]
+    tau.se <- coef(summary(tau.ols))[2,2]
     return(c(estimate=tau.est, std.err=tau.se))
   }
   

--- a/r-package/grf/R/average_treatment_effect.R
+++ b/r-package/grf/R/average_treatment_effect.R
@@ -8,6 +8,12 @@
 #'   sum_{Wi = 1} E[Y(1) - Y(0) | X = Xi] / |{i : Wi = 1}|
 #' The (conditional) average treatment effect on the controls (target.sample = control):
 #'   sum_{Wi = 0} E[Y(1) - Y(0) | X = Xi] / |{i : Wi = 0}|
+#' The overlap-weighted (conditional) average treatment effect
+#'   sum_{i = 1}^n e(Xi) (1 - e(Xi)) E[Y(1) - Y(0) | X = Xi] / sum_{i = 1}^n e(Xi) (1 - e(Xi)),
+#' where e(x) = P[Wi = 1 | Xi = x]. This last estimand is recommended by
+#' Li, Morgan, and Zaslavsky (JASA, 2017) in case of poor overlap
+#' (i.e., when the propensities e(x) may be very close to 0 or 1), as it doesn't
+#' involve dividing by estimated propensities.
 #'
 #' @param forest The trained forest.
 #' @param target.sample Which sample to aggregate treatment effects over.
@@ -39,9 +45,12 @@
 #' @return An estimate of the average treatment effect, along with standard error.
 #' @export
 average_treatment_effect = function(forest,
-                                    target.sample=c("all", "treated", "control"),
+                                    target.sample=c("all", "treated", "control", "overlap"),
                                     method=c("AIPW", "TMLE")) {
 
+  target.sample <- match.arg(target.sample)
+  method <- match.arg(method)
+  
   if (!("causal_forest" %in% class(forest))) {
     stop("Average effect estimation only implemented for causal_forest")
   }
@@ -50,13 +59,46 @@ average_treatment_effect = function(forest,
     stop("For average effect estimation to work, please train with precompute.nuisance = TRUE")
   }
   
+  #
+  # Address the overlap case separately, as this is a very different estimation problem.
+  # The method argument (AIPW vs TMLE) is ignored in this case, as both methods are effectively
+  # the same here. Also, note that the overlap-weighted estimator generalizes naturally to the
+  # non-binary W case -- see, e.g., Robinson (Econometrica, 1988) -- and so we do not require
+  # W to be binary here.
+  #
+  
+  if (method == "overlap") {
+    W.residual = forest$W.orig - forest$W.hat
+    Y.residual = forest$Y.orig - forest$Y.hat
+    tau.ols = lm(Y.residual ~ W.residual + 0)
+    tau.est <- coef(summary(tau.ols))[1,1]
+    tau.se <- coef(summary(tau.ols))[1,2]
+    return(c(estimate=tau.est, std.err=tau.se))
+  }
+  
   if (!all(forest$W.orig %in% c(0, 1))) {
     stop(paste("Average treatment effect estimation only implemented for binary treatment.",
                "See `average_partial_effect` for continuous W."))
   }
   
-  target.sample <- match.arg(target.sample)
-  method <- match.arg(method)
+  if (min(forest$W.hat) <= 0.01 && max(forest$W.hat) >= 0.99) {
+    rng = range(forest$W.hat)
+    warning(paste0("Estimated treatment propensities take values between ",
+                   round(rng[1], 3), " and ", round(rng[2], 3),
+                   " and in particular get very close to 0 and 1. ",
+                   "In this case, using `target.sample=overlap`, or filtering data as in ",
+                   "Crump, Hotz, Imbens, and Mitnik (Biometrika, 2009) may be helpful."))
+  } else if (min(forest$W.hat) <= 0.01 && target.sample != "treated") {
+    warning(paste0("Estimated treatment propensities go as low as ",
+                   round(min(forest$W.hat), 3), " which means that treatment ",
+                   "effects for some controls may not be well identified. ",
+                   "In this case, using `target.sample=treated` may be helpful."))
+  } else if (max(forest$W.hat) >= 0.99 && target.sample != "control") {
+    warning(paste0("Estimated treatment propensities go as high as ",
+                   round(max(forest$W.hat), 3), " which means that treatment ",
+                   "effects for some treated units may not be well identified. ",
+                   "In this case, using `target.sample=control` may be helpful."))
+  }
   
   control.idx <- which(forest$W.orig == 0)
   treated.idx <- which(forest$W.orig == 1)

--- a/r-package/grf/tests/testthat/test_print.R
+++ b/r-package/grf/tests/testthat/test_print.R
@@ -1,32 +1,33 @@
 test_that("basic printing is successful", {
-	p = 4
-	n = 50
-	i = 2
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	Y = rnorm(n) * (1 + (X[,i] > 0))
-	D = data.frame(X=X, Y=Y)
-	q.forest = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), num.trees = 50)
-    capture.output(print(q.forest))
+  p = 4
+  n = 50
+  i = 2
+  X = matrix(2 * runif(n * p) - 1, n, p)
+  Y = rnorm(n) * (1 + (X[,i] > 0))
+  D = data.frame(X=X, Y=Y)
+  q.forest = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), num.trees = 50)
+  capture_output(print(q.forest))
+  expect_true(TRUE)
 })
 
 test_that("printing a forest with one regressor is successful", {
-	n = 50; p = 1
-	X = matrix(rnorm(n * p), n, p)
-	Y = X * rnorm(n)
-	r.forest = regression_forest(X, Y)
-	capture.output(print(r.forest))
+  n = 50; p = 1
+  X = matrix(rnorm(n * p), n, p)
+  Y = X[,1] * rnorm(n)
+  r.forest = regression_forest(X, Y)
+  capture_output(print(r.forest))
+  expect_true(TRUE)
 })
 
-test_that("basic tree printing is successful", {
-	p = 4
-	n = 50
-	i = 2
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	Y = rnorm(n) * (1 + (X[,i] > 0))
-	D = data.frame(X=X, Y=Y)
-
-	q.forest = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), num.trees = 50)
-	q.tree = get_tree(q.forest, 1)
-
-    capture.output(print(q.tree))
-})
+ test_that("basic tree printing is successful", {
+  p = 4
+  n = 50
+  i = 2
+  X = matrix(2 * runif(n * p) - 1, n, p)
+  Y = rnorm(n) * (1 + (X[,i] > 0))
+  D = data.frame(X=X, Y=Y)
+  q.forest = quantile_forest(X, Y, quantiles = c(0.1, 0.5, 0.9), num.trees = 50)
+  q.tree = get_tree(q.forest, 1)
+  capture_output(print(q.tree))
+  expect_true(TRUE)
+ })


### PR DESCRIPTION
The overlap-weighted effect is useful in situations with poor overlap (Li et al., 2017), and is defined as sum_{i = 1}^n e(Xi) (1 - e(Xi)) E[Y(1) - Y(0) | X = Xi] / sum_{i = 1}^n e(Xi) (1 - e(Xi)).

Addresses #176.