### PR TITLE
For each tree, switch to storing the samples which were drawn as opposed to out-of-bag.

### DIFF
--- a/core/src/forest/ForestPredictor.cpp
+++ b/core/src/forest/ForestPredictor.cpp
@@ -61,17 +61,15 @@ std::vector<std::vector<bool>> ForestPredictor::get_valid_trees_by_sample(const 
   size_t num_trees = forest.get_trees().size();
   size_t num_samples = data->get_num_rows();
 
-  if (!oob_prediction) {
-    return std::vector<std::vector<bool>>(num_samples, std::vector<bool>(num_trees, true));
-  } else {
-    std::vector<std::vector<bool>> result(num_samples, std::vector<bool>(num_trees));
+  std::vector<std::vector<bool>> result(num_samples, std::vector<bool>(num_trees, true));
+  if (oob_prediction) {
     for (size_t tree_idx = 0; tree_idx < num_trees; ++tree_idx) {
-      for (size_t sample : forest.get_trees()[tree_idx]->get_oob_samples()) {
-        result[sample][tree_idx] = true;
+      for (size_t sample : forest.get_trees()[tree_idx]->get_drawn_samples()) {
+        result[sample][tree_idx] = false;
       }
     }
-    return result;
   }
+  return result;
 }
 
 std::vector<std::vector<size_t>> ForestPredictor::find_leaf_nodes(
@@ -137,13 +135,11 @@ std::vector<std::vector<size_t>> ForestPredictor::find_batch(
 std::vector<bool> ForestPredictor::get_valid_samples(size_t num_samples,
                                                      std::shared_ptr<Tree> tree,
                                                      bool oob_prediction) const {
-  if (!oob_prediction) {
-    return std::vector<bool>(num_samples, true);
-  } else {
-    std::vector<bool> valid_samples(num_samples, false);
-    for (size_t sample : tree->get_oob_samples()) {
-      valid_samples[sample] = true;
+  std::vector<bool> valid_samples(num_samples, true);
+  if (oob_prediction) {
+    for (size_t sample : tree->get_drawn_samples()) {
+      valid_samples[sample] = false;
     }
-    return valid_samples;
   }
+  return valid_samples;
 }

--- a/core/src/forest/ForestPredictor.h
+++ b/core/src/forest/ForestPredictor.h
@@ -50,8 +50,9 @@ private:
                                   Data* prediction_data,
                                   bool oob_prediction) const;
 
-  std::vector<std::vector<bool>> get_trees_by_sample(const Forest &forest,
-                                                     Data *data) const;
+  std::vector<std::vector<bool>> get_valid_trees_by_sample(const Forest &forest,
+                                                           Data* data,
+                                                           bool oob_prediction) const;
 
   std::vector<std::vector<size_t>> find_leaf_nodes(
       const Forest &forest,

--- a/core/src/forest/ForestPredictor.h
+++ b/core/src/forest/ForestPredictor.h
@@ -66,6 +66,9 @@ private:
       Data *prediction_data,
       bool oob_prediction) const;
 
+  std::vector<bool> get_valid_samples(size_t num_samples,
+                                      std::shared_ptr<Tree> tree,
+                                      bool oob_prediction) const;
 
 private:
   uint num_threads;

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -119,7 +119,7 @@ std::vector<std::shared_ptr<Tree>> ForestTrainer::train_batch(
 
       std::shared_ptr<Tree> tree = tree_trainer.train(data, observations,
           sampler, samples, options.get_tree_options());
-      tree->set_oob_samples(oob_samples);
+      tree->set_drawn_samples(samples);
       trees.push_back(tree);
     } else {
       std::vector<std::shared_ptr<Tree>> group = train_ci_group(data, observations, sampler, options);
@@ -149,7 +149,7 @@ std::vector<std::shared_ptr<Tree>> ForestTrainer::train_ci_group(Data* data,
 
     std::shared_ptr<Tree> tree = tree_trainer.train(data, observations,
         sampler, subsample, options.get_tree_options());
-    tree->set_oob_samples(oob_subsample);
+    tree->set_drawn_samples(subsample);
     trees.push_back(tree);
   }
   return trees;

--- a/core/src/forest/ForestTrainer.cpp
+++ b/core/src/forest/ForestTrainer.cpp
@@ -115,7 +115,7 @@ std::vector<std::shared_ptr<Tree>> ForestTrainer::train_batch(
     if (ci_group_size == 1) {
       std::vector<size_t> samples;
       std::vector<size_t> oob_samples;
-      sampler.sample(data->get_num_rows(), options.get_sample_fraction(), samples, oob_samples);
+      sampler.sample(data->get_num_rows(), options.get_sample_fraction(), samples);
 
       std::shared_ptr<Tree> tree = tree_trainer.train(data, observations,
           sampler, samples, options.get_tree_options());
@@ -136,16 +136,13 @@ std::vector<std::shared_ptr<Tree>> ForestTrainer::train_ci_group(Data* data,
   std::vector<std::shared_ptr<Tree>> trees;
 
   std::vector<size_t> sample;
-  std::vector<size_t> oob_sample;
-  sampler.sample(data->get_num_rows(), 0.5, sample, oob_sample);
+  sampler.sample(data->get_num_rows(), 0.5, sample);
 
   double sample_fraction = options.get_sample_fraction();
 
   for (size_t i = 0; i < options.get_ci_group_size(); ++i) {
     std::vector<size_t> subsample;
-    std::vector<size_t> oob_subsample;
-    sampler.subsample(sample, sample_fraction * 2, subsample, oob_subsample);
-    oob_subsample.insert(oob_subsample.end(), oob_sample.begin(), oob_sample.end());
+    sampler.subsample(sample, sample_fraction * 2, subsample);
 
     std::shared_ptr<Tree> tree = tree_trainer.train(data, observations,
         sampler, subsample, options.get_tree_options());

--- a/core/src/prediction/collector/DefaultPredictionCollector.cpp
+++ b/core/src/prediction/collector/DefaultPredictionCollector.cpp
@@ -24,7 +24,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     const Forest& forest,
     Data* prediction_data,
     const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
-    const std::vector<std::vector<bool>>& trees_by_sample) {
+    const std::vector<std::vector<bool>>& valid_trees_by_sample) {
 
   size_t num_samples = prediction_data->get_num_rows();
   std::vector<Prediction> predictions;
@@ -36,7 +36,7 @@ std::vector<Prediction> DefaultPredictionCollector::collect_predictions(
     // Create a list of weighted neighbors for this sample.
     uint num_leaves = 0;
     for (size_t tree_index = 0; tree_index < forest.get_trees().size(); ++tree_index) {
-      if (!trees_by_sample.empty() && !trees_by_sample[sample][tree_index]) {
+      if (!valid_trees_by_sample[sample][tree_index]) {
         continue;
       }
 

--- a/core/src/prediction/collector/DefaultPredictionCollector.h
+++ b/core/src/prediction/collector/DefaultPredictionCollector.h
@@ -30,7 +30,7 @@ public:
   std::vector<Prediction> collect_predictions(const Forest &forest,
                                               Data *prediction_data,
                                               const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
-                                              const std::vector<std::vector<bool>>& trees_by_sample);
+                                              const std::vector<std::vector<bool>>& valid_trees_by_sample);
 private:
   void add_sample_weights(const std::vector<size_t>& samples,
                           std::unordered_map<size_t, double>& weights_by_sample);

--- a/core/src/prediction/collector/OptimizedPredictionCollector.cpp
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.cpp
@@ -25,7 +25,7 @@ OptimizedPredictionCollector::OptimizedPredictionCollector(std::shared_ptr<Optim
 std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const Forest& forest,
                                                                           Data* prediction_data,
                                                                           const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
-                                                                          const std::vector<std::vector<bool>>& trees_by_sample) {
+                                                                          const std::vector<std::vector<bool>>& valid_trees_by_sample) {
   size_t num_trees = forest.get_trees().size();
   size_t num_samples = prediction_data->get_num_rows();
 
@@ -42,7 +42,7 @@ std::vector<Prediction> OptimizedPredictionCollector::collect_predictions(const 
     // Create a list of weighted neighbors for this sample.
     uint num_leaves = 0;
     for (size_t tree_index = 0; tree_index < forest.get_trees().size(); ++tree_index) {
-      if (!trees_by_sample.empty() && !trees_by_sample[sample][tree_index]) {
+      if (!valid_trees_by_sample[sample][tree_index]) {
         continue;
       }
 

--- a/core/src/prediction/collector/OptimizedPredictionCollector.h
+++ b/core/src/prediction/collector/OptimizedPredictionCollector.h
@@ -30,7 +30,7 @@ public:
   std::vector<Prediction> collect_predictions(const Forest &forest,
                                               Data *prediction_data,
                                               const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
-                                              const std::vector<std::vector<bool>>& trees_by_sample);
+                                              const std::vector<std::vector<bool>>& valid_trees_by_sample);
 
 private:
   void add_prediction_values(size_t node,

--- a/core/src/prediction/collector/PredictionCollector.h
+++ b/core/src/prediction/collector/PredictionCollector.h
@@ -25,7 +25,7 @@ public:
   virtual std::vector<Prediction> collect_predictions(const Forest& forest,
                                                       Data* prediction_data,
                                                       const std::vector<std::vector<size_t>>& leaf_nodes_by_tree,
-                                                      const std::vector<std::vector<bool>>& trees_by_sample) = 0;
+                                                      const std::vector<std::vector<bool>>& valid_trees_by_sample) = 0;
 };
 
 #endif //GRF_PREDICTIONCOLLECTOR_H

--- a/core/src/sampling/RandomSampler.h
+++ b/core/src/sampling/RandomSampler.h
@@ -34,8 +34,11 @@ public:
 
   void sample(size_t num_samples,
               double sample_fraction,
-              std::vector<size_t>& samples,
-              std::vector<size_t>& oob_samples);
+              std::vector<size_t>& samples);
+
+  void subsample(const std::vector<size_t>& samples,
+                 double sample_fraction,
+                 std::vector<size_t>& subsamples);
 
   void subsample(const std::vector<size_t>& samples,
                  double sample_fraction,
@@ -80,39 +83,34 @@ public:
                                          const std::vector<double>& weights);
 
   /**
-   * Create numbers from 0 to n_all-1, shuffle and split in two parts.
-   * @param first_part First part
-   * @param second_part Second part
+   * Create numbers from 0 to n_all-1, then shuffle and select the first 'size' elements.
+   *
+   * @param samples A list of first 'size'n_first shuffled numbers
    * @param n_all Number elements
-   * @param n_first Number of elements of first part
+   * @param size Number of elements of to select
    */
-  void shuffle_and_split(std::vector<size_t>& first_part,
-                         std::vector<size_t>& second_part,
+  void shuffle_and_split(std::vector<size_t>& samples,
                          size_t n_all,
-                         size_t n_first);
+                         size_t size);
 
   size_t sample_poisson(size_t mean);
 
 private:
   void bootstrap(size_t num_samples,
                  double sample_fraction,
-                 std::vector<size_t>& samples,
-                 std::vector<size_t>& oob_sample);
+                 std::vector<size_t>& samples);
 
   void bootstrap_without_replacement(size_t num_samples,
                                      double sample_fraction,
-                                     std::vector<size_t>& samples,
-                                     std::vector<size_t>& oob_samples);
+                                     std::vector<size_t>& samples);
 
   void bootstrap_weighted(size_t num_samples,
                           double sample_fraction,
-                          std::vector<size_t>& samples,
-                          std::vector<size_t>& oob_samples);
+                          std::vector<size_t>& samples);
 
   void bootstrap_without_replacement_weighted(size_t num_samples,
                                               double sample_fraction,
-                                              std::vector<size_t>& samples,
-                                              std::vector<size_t>& oob_samples);
+                                              std::vector<size_t>& samples);
 
   /**
    * Simple algorithm for sampling without replacement, faster for smaller num_samples

--- a/core/src/serialization/TreeSerializer.cpp
+++ b/core/src/serialization/TreeSerializer.cpp
@@ -28,7 +28,7 @@ void TreeSerializer::serialize(std::ostream& stream, const std::shared_ptr<Tree>
   write_matrix(tree->get_leaf_samples(), stream);
   write_vector(tree->get_split_vars(), stream);
   write_vector(tree->get_split_values(), stream);
-  write_vector(tree->get_oob_samples(), stream);
+  write_vector(tree->get_drawn_samples(), stream);
 
   PredictionValuesSerializer prediction_values_serializer;
   prediction_values_serializer.serialize(stream, tree->get_prediction_values());
@@ -50,8 +50,8 @@ std::shared_ptr<Tree> TreeSerializer::deserialize(std::istream& stream) {
   std::vector<double> split_values;
   read_vector(split_values, stream);
 
-  std::vector<size_t> oob_samples;
-  read_vector(oob_samples, stream);
+  std::vector<size_t> drawn_samples;
+  read_vector(drawn_samples, stream);
 
   PredictionValuesSerializer prediction_values_serializer;
   PredictionValues prediction_values = prediction_values_serializer.deserialize(stream);
@@ -62,6 +62,6 @@ std::shared_ptr<Tree> TreeSerializer::deserialize(std::istream& stream) {
                samples,
                split_vars,
                split_values,
-               oob_samples,
+               drawn_samples,
                prediction_values));
 }

--- a/core/src/tree/Tree.cpp
+++ b/core/src/tree/Tree.cpp
@@ -26,14 +26,14 @@ Tree::Tree(size_t root_node,
            const std::vector<std::vector<size_t>>& leaf_samples,
            const std::vector<size_t>& split_vars,
            const std::vector<double>& split_values,
-           const std::vector<size_t>& oob_samples,
+           const std::vector<size_t>& drawn_samples,
            const PredictionValues& prediction_values) :
     root_node(root_node),
     child_nodes(child_nodes),
     leaf_samples(leaf_samples),
     split_vars(split_vars),
     split_values(split_values),
-    oob_samples(oob_samples),
+    drawn_samples(drawn_samples),
     prediction_values(prediction_values) {}
 
 std::vector<size_t> Tree::find_leaf_nodes(Data* prediction_data,

--- a/core/src/tree/Tree.h
+++ b/core/src/tree/Tree.h
@@ -41,13 +41,27 @@ public:
   /**
    * Given test data and a list of sample IDs, recurses down the tree to find
    * the leaf node IDs that those samples belong in.
+   *
+   * @param prediction_data: the data matrix containing all test samples.
+   * @param samples: a list of sample IDs whose leaf nodes should be calculated.
+   * @return The resulting node IDs for each sample ID in the input. For efficiency reasons, this
+   * vector's length will be equal to the total number of test samples, and the index for each
+   * requested sample ID will contain the corresponding node ID. All other values will be 0.
    */
   std::vector<size_t> find_leaf_nodes(Data* prediction_data,
                                       const std::vector<size_t>& samples);
 
   /**
-   * Given test data and a list of sample IDs, recurses down the tree to find
-   * the leaf node IDs that those samples belong in.
+   * Given test data and a vector indicating which samples to consider, recurses
+   * down the tree to find the leaf node IDs that those samples belong in.
+   *
+   * @param prediction_data: the data matrix containing all test samples.
+   * @param samples: a vector indicating which samples should have their leaf nodes
+   * calculated. This vector's length should be equal to the total number of samples, and
+   * contain 'true' for a sample ID's index if that sample's leaf node should be calculated.
+   * @return The resulting node IDs for each sample ID in the input. For efficiency reasons, this
+   * vector's length will be equal to the total number of test samples, and the index for each
+   * requested sample ID will contain the corresponding node ID. All other values will be 0.
    */
   std::vector<size_t> find_leaf_nodes(Data* prediction_data,
                                       const std::vector<bool>& valid_samples);
@@ -116,16 +130,32 @@ public:
     return prediction_values;
   }
 
+  /**
+   * Given a node ID, returns true if the node represents a leaf in this tree (in
+   * particular, the node has no children).
+   */
   bool is_leaf(size_t node);
 
-  void set_leaf_nodes(const std::vector<std::vector<size_t>>& leaf_nodes) {
-    this->leaf_samples = leaf_nodes;
+  /**
+   * Sets the contents of this tree's leaf nodes. Please see
+   * Tree::get_leaf_samples for a description of this variable.
+   */
+  void set_leaf_samples(const std::vector<std::vector<size_t>>& leaf_samples) {
+    this->leaf_samples = leaf_samples;
   }
 
+  /**
+   * Sets the contents of this tree's OOB samples. Please see
+   * Tree::get_oob_samples for a description of this variable.
+   */
   void set_oob_samples(const std::vector<size_t> &oob_samples) {
     this->oob_samples = oob_samples;
   }
 
+  /**
+   * Sets the contents of this tree's prediction values. Please see
+   * Tree::get_prediction_values for a description of this variable.
+   */
   void set_prediction_values(const PredictionValues& prediction_values) {
     this->prediction_values = prediction_values;
   }

--- a/core/src/tree/Tree.h
+++ b/core/src/tree/Tree.h
@@ -46,6 +46,12 @@ public:
                                       const std::vector<size_t>& samples);
 
   /**
+   * Given test data and a list of sample IDs, recurses down the tree to find
+   * the leaf node IDs that those samples belong in.
+   */
+  std::vector<size_t> find_leaf_nodes(Data* prediction_data,
+                                      const std::vector<bool>& valid_samples);
+  /**
    * Removes all empty leaf nodes.
    *
    * When re-populating the leaves of an honest tree, certain leaf nodes may become empty.
@@ -125,6 +131,8 @@ public:
   }
 
 private:
+  size_t find_leaf_node(Data* prediction_data,
+                        size_t sample);
   void prune_node(size_t& node);
   bool is_empty_leaf(size_t node);
 

--- a/core/src/tree/Tree.h
+++ b/core/src/tree/Tree.h
@@ -35,7 +35,7 @@ public:
        const std::vector<std::vector<size_t>>& leaf_samples,
        const std::vector<size_t>& split_vars,
        const std::vector<double>& split_values,
-       const std::vector<size_t>& oob_samples,
+       const std::vector<size_t>& drawn_samples,
        const PredictionValues& prediction_values);
 
   /**
@@ -118,8 +118,8 @@ public:
    * this excludes both samples that went into growing the tree, as well as samples
    * used to repopulate the leaves.
    */
-  const std::vector<size_t>& get_oob_samples() {
-    return oob_samples;
+  const std::vector<size_t>& get_drawn_samples() {
+    return drawn_samples;
   }
 
   /**
@@ -145,11 +145,11 @@ public:
   }
 
   /**
-   * Sets the contents of this tree's OOB samples. Please see
-   * Tree::get_oob_samples for a description of this variable.
+   * Sets the contents of this tree's drawn samples. Please see
+   * Tree::get_drawn_samples for a description of this variable.
    */
-  void set_oob_samples(const std::vector<size_t> &oob_samples) {
-    this->oob_samples = oob_samples;
+  void set_drawn_samples(const std::vector<size_t>& drawn_samples) {
+    this->drawn_samples = drawn_samples;
   }
 
   /**
@@ -173,6 +173,7 @@ private:
   std::vector<double> split_values;
 
   std::vector<size_t> oob_samples;
+  std::vector<size_t> drawn_samples;
 
   PredictionValues prediction_values;
 };

--- a/core/src/tree/TreeTrainer.cpp
+++ b/core/src/tree/TreeTrainer.cpp
@@ -114,7 +114,7 @@ void TreeTrainer::repopulate_leaf_nodes(std::shared_ptr<Tree> tree,
     size_t leaf_node = leaf_nodes.at(sample);
     new_leaf_nodes.at(leaf_node).push_back(sample);
   }
-  tree->set_leaf_nodes(new_leaf_nodes);
+  tree->set_leaf_samples(new_leaf_nodes);
   tree->prune_empty_leaves();
 }
 

--- a/core/test/sampling/RandomSamplerTest.cpp
+++ b/core/test/sampling/RandomSamplerTest.cpp
@@ -189,13 +189,11 @@ TEST_CASE("Shuffle and split 1", "[shuffleAndSplit]") {
   SamplingOptions sampling_options(true);
   RandomSampler sampler(random_device(), sampling_options);
 
-  std::vector<size_t> first_part;
-  std::vector<size_t> second_part;
+  std::vector<size_t> samples;
 
-  sampler.shuffle_and_split(first_part, second_part, 10, 3);
+  sampler.shuffle_and_split(samples, 10, 3);
 
-  REQUIRE(3 == first_part.size());
-  REQUIRE(7 == second_part.size());
+  REQUIRE(3 == samples.size());
 }
 
 TEST_CASE("Shuffle and split 2", "[shuffleAndSplit]") {
@@ -204,13 +202,11 @@ TEST_CASE("Shuffle and split 2", "[shuffleAndSplit]") {
   SamplingOptions sampling_options(true);
   RandomSampler sampler(random_device(), sampling_options);
 
-  std::vector<size_t> first_part;
-  std::vector<size_t> second_part;
+  std::vector<size_t> samples;
 
-  sampler.shuffle_and_split(first_part, second_part, 100, 63);
+  sampler.shuffle_and_split(samples, 100, 63);
 
-  REQUIRE(63 == first_part.size());
-  REQUIRE(37 == second_part.size());
+  REQUIRE(63 == samples.size());
 }
 
 TEST_CASE("Shuffle and split 3", "[shuffleAndSplit]") {
@@ -219,13 +215,11 @@ TEST_CASE("Shuffle and split 3", "[shuffleAndSplit]") {
   SamplingOptions sampling_options(true);
   RandomSampler sampler(random_device(), sampling_options);
 
-  std::vector<size_t> first_part;
-  std::vector<size_t> second_part;
+  std::vector<size_t> samples;
 
-  sampler.shuffle_and_split(first_part, second_part, 1, 1);
+  sampler.shuffle_and_split(samples, 1, 1);
 
-  REQUIRE(1 == first_part.size());
-  REQUIRE(0 == second_part.size());
+  REQUIRE(1 == samples.size());
 }
 
 TEST_CASE("Shuffle and split 4", "[shuffleAndSplit]") {
@@ -234,11 +228,9 @@ TEST_CASE("Shuffle and split 4", "[shuffleAndSplit]") {
   SamplingOptions sampling_options(true);
   RandomSampler sampler(random_device(), sampling_options);
   
-  std::vector<size_t> first_part;
-  std::vector<size_t> second_part;
+  std::vector<size_t> samples;
 
-  sampler.shuffle_and_split(first_part, second_part, 3, 0);
+  sampler.shuffle_and_split(samples, 3, 0);
 
-  REQUIRE(0 == first_part.size());
-  REQUIRE(3 == second_part.size());
+  REQUIRE(0 == samples.size());
 }

--- a/core/test/serialization/SerializationTest.cpp
+++ b/core/test/serialization/SerializationTest.cpp
@@ -66,7 +66,7 @@ TEST_CASE("trees serialize and deserialize correctly", "[treeSerialization]") {
   REQUIRE(tree->get_child_nodes().size() == original_tree->get_child_nodes().size());
   REQUIRE(tree->get_split_vars().size() == original_tree->get_split_vars().size());
   REQUIRE(tree->get_split_values().size() == original_tree->get_split_values().size());
-  REQUIRE(tree->get_oob_samples().size() == original_tree->get_oob_samples().size());
+  REQUIRE(tree->get_drawn_samples().size() == original_tree->get_drawn_samples().size());
 }
 
 TEST_CASE("forests serialize and deserialize correctly", "[forestSerialization]") {

--- a/r-package/grf/bindings/AnalysisBindings.cpp
+++ b/r-package/grf/bindings/AnalysisBindings.cpp
@@ -96,12 +96,12 @@ Rcpp::List deserialize_tree(Rcpp::List forest_object,
     node_objects.push_back(node_object);
   }
 
-  const std::vector<size_t>& oob_samples = tree->get_oob_samples();
+  const std::vector<size_t>& drawn_samples = tree->get_drawn_samples();
   size_t num_samples = forest.get_observations().get_num_samples();
 
   Rcpp::List result;
-  result.push_back(num_samples - oob_samples.size(), "num_samples");
-  result.push_back(oob_samples, "oob_samples");
+  result.push_back(drawn_samples.size(), "num_samples");
+  result.push_back(drawn_samples, "drawn_samples");
   result.push_back(node_objects, "nodes");
   return result;
 }


### PR DESCRIPTION
Addresses #145.

In experiments using a sample fraction of 0.10, this shows a ~40% reduction in peak memory usage.