### PR TITLE
Compute OOB predictions during training

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,16 +107,6 @@ tau.forest = causal_forest(X[, selected.vars], Y, W,
                            W.hat = W.hat, Y.hat = Y.hat,
                            tune.parameters = TRUE)
 tau.hat = predict(tau.forest)$predictions
-
-# A simple omnibus test for signal uses tau.hat as a linear predictor for CATE.
-# A coefficient of 1 in the regression below suggests that tau.hat is well calibrated.
-DF = data.frame(dY = Y - Y.hat, dY.hat = (W - W.hat) * tau.hat)
-best.linear.predictor = lm(dY ~ dY.hat + 0, data = DF)
-
-# We need to use some extra packages to get
-# heteroskedasticity-consistent inference.
-lmtest::coeftest(best.linear.predictor,
-                 vcov = sandwich::vcovHC)
 ```
 
 ### Developing

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ X.test = matrix(0, 101, p)
 X.test[,1] = seq(-2, 2, length.out = 101)
 
 # Train a causal forest.
-W = rbinom(n, 1, 0.25 + 0.5 * (X[,1] > 0))
+W = rbinom(n, 1, 0.5)
 Y = pmax(X[,1], 0) * W + X[,2] + pmin(X[,3], 0) + rnorm(n)
 tau.forest = causal_forest(X, Y, W)
 

--- a/r-package/grf/R/regression_forest.R
+++ b/r-package/grf/R/regression_forest.R
@@ -22,6 +22,7 @@
 #'                      be at least 2.
 #' @param alpha A tuning parameter that controls the maximum imbalance of a split.
 #' @param imbalance.penalty A tuning parameter that controls how harshly imbalanced splits are penalized.
+#' @param compute.oob.predictions Whether OOB predictions on training set should be precomputed.
 #' @param seed The seed for the C++ random number generator.
 #' @param clusters Vector of integers or factors specifying which cluster each observation corresponds to.
 #' @param samples_per_cluster If sampling by cluster, the number of observations to be sampled from
@@ -67,6 +68,7 @@ regression_forest <- function(X, Y,
                               ci.group.size = 2,
                               alpha = NULL,
                               imbalance.penalty = NULL,
+                              compute.oob.predictions = TRUE,
                               seed = NULL,
                               clusters = NULL,
                               samples_per_cluster = NULL,
@@ -123,13 +125,20 @@ regression_forest <- function(X, Y,
                                as.numeric(tunable.params["imbalance.penalty"]),
                                clusters,
                                samples_per_cluster)
-    
+
     forest[["ci.group.size"]] <- ci.group.size
     forest[["X.orig"]] <- X
     forest[["clusters"]] <- clusters
     forest[["tunable.params"]] <- tunable.params
-    
+
     class(forest) <- c("regression_forest", "grf")
+
+    if (compute.oob.predictions) {
+        oob.pred <- predict(forest)
+        forest[["predictions"]] <- oob.pred$predictions
+        forest[["debiased.error"]] <- oob.pred$debiased.error
+    }
+
     forest
 }
 
@@ -186,49 +195,60 @@ predict.regression_forest <- function(object, newdata = NULL,
                                       num.threads = NULL,
                                       estimate.variance = FALSE,
                                       ...) {
+
+    local.linear <- !is.null(linear.correction.variables)
+
+    # If possible, use pre-computed predictions.
+    if (is.null(newdata) & !estimate.variance & !local.linear & !is.null(object$predictions)) {
+        return(data.frame(predictions=object$predictions,
+                          debiased.error=object$debiased.error))
+    }
+
     num.threads <- validate_num_threads(num.threads)
 
     if (estimate.variance) {
-        ci.group.size = object$ci.group.size
+        ci.group.size <- object$ci.group.size
     } else {
-        ci.group.size = 1
+        ci.group.size <- 1
     }
 
     if (ridge.type == "standardized") {
-        use_unweighted_penalty = 0
+        use_unweighted_penalty <- 0
     } else if (ridge.type == "identity") {
-        use_unweighted_penalty = 1
+        use_unweighted_penalty <- 1
     } else {
         stop("Error: invalid ridge type")
     }
 
     forest.short <- object[-which(names(object) == "X.orig")]
-    X.orig = object[["X.orig"]]
-
-    local.linear = !is.null(linear.correction.variables)
+    X.orig <- object[["X.orig"]]
 
     # subtract 1 for C++ indexing
     if (local.linear) {
-        linear.correction.variables = linear.correction.variables - 1
+        linear.correction.variables <- linear.correction.variables - 1
     }
 
     if (!is.null(newdata) ) {
         data <- create_data_matrices(newdata)
         if (!local.linear) {
-            regression_predict(forest.short, data$default, data$sparse,
+            ret <- regression_predict(forest.short, data$default, data$sparse,
                 num.threads, ci.group.size)
         } else {
             training.data <- create_data_matrices(X.orig)
-            local_linear_predict(forest.short, data$default, training.data$default, data$sparse,
+            ret <- local_linear_predict(forest.short, data$default, training.data$default, data$sparse,
                 training.data$sparse, lambda, use_unweighted_penalty, linear.correction.variables, num.threads)
         }
     } else {
         data <- create_data_matrices(X.orig)
         if (!local.linear) {
-            regression_predict_oob(forest.short, data$default, data$sparse, num.threads, ci.group.size)
+            ret <- regression_predict_oob(forest.short, data$default, data$sparse, num.threads, ci.group.size)
         } else {
-            local_linear_predict_oob(forest.short, data$default, data$sparse, lambda, use_unweighted_penalty,
+            ret <- local_linear_predict_oob(forest.short, data$default, data$sparse, lambda, use_unweighted_penalty,
                 linear.correction.variables, num.threads)
         }
     }
+
+    # Convert list to data frame.
+    empty = sapply(ret, function(elem) length(elem) == 0)
+    do.call(cbind.data.frame, ret[!empty])
 }

--- a/r-package/grf/tests/testthat/test_causal_forest.R
+++ b/r-package/grf/tests/testthat/test_causal_forest.R
@@ -3,139 +3,144 @@ library(grf)
 set.seed(3141)
 
 test_that("causal forests give reasonable estimates", {
-	p = 6
-	n = 1000
-
-	ticks = 101
-	X.test = matrix(0, ticks, p)
-	xvals = seq(-1, 1, length.out = ticks)
-	X.test[,1] = xvals
-	truth = 2 * (xvals > 0)
-
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	W = rbinom(n, 1, 0.5)
-	Y = (X[,1] > 0) * (2 * W  - 1) + 2 * rnorm(n)
-
-	forest.causal = causal_forest(X, Y, W, num.trees = 2000, ci.group.size = 4, W.hat = 0.5)
-	preds.causal.oob = predict(forest.causal, estimate.variance=TRUE)
-	preds.causal = predict(forest.causal, X.test, estimate.variance=TRUE)
-
-	expect_true(all(preds.causal$variance.estimate > 0))
-	expect_true(all(preds.causal.oob$variance.estimate > 0))
-	
-	error = preds.causal$predictions - truth
-	expect_true(mean(error^2) < 0.5)
-	
-	truth.oob = 2 * (X[,1] > 0)
-	error.oob = preds.causal.oob$predictions - truth.oob
-	expect_true(mean(error.oob^2) < 0.5)
-	
-	Z.oob = error.oob / sqrt(preds.causal.oob$variance.estimate)
-	expect_true(mean(abs(Z.oob) > 1) < 0.5)
+    p = 6
+    n = 1000
+    
+    ticks = 101
+    X.test = matrix(0, ticks, p)
+    xvals = seq(-1, 1, length.out = ticks)
+    X.test[,1] = xvals
+    truth = 2 * (xvals > 0)
+    
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    W = rbinom(n, 1, 0.5)
+    Y = (X[,1] > 0) * (2 * W  - 1) + 2 * rnorm(n)
+    
+    forest.causal = causal_forest(X, Y, W, num.trees = 2000, ci.group.size = 4, W.hat = 0.5)
+    preds.causal.oob = predict(forest.causal, estimate.variance=TRUE)
+    preds.causal = predict(forest.causal, X.test, estimate.variance=TRUE)
+    
+    expect_true(all(preds.causal$variance.estimate > 0))
+    expect_true(all(preds.causal.oob$variance.estimate > 0))
+    
+    error = preds.causal$predictions - truth
+    expect_true(mean(error^2) < 0.5)
+    
+    truth.oob = 2 * (X[,1] > 0)
+    error.oob = preds.causal.oob$predictions - truth.oob
+    expect_true(mean(error.oob^2) < 0.5)
+    
+    Z.oob = error.oob / sqrt(preds.causal.oob$variance.estimate)
+    expect_true(mean(abs(Z.oob) > 1) < 0.5)
 })
 
 test_that("causal forests can split on the last parameter", {
-	n = 1000
-	p = 6
-	X = matrix(rnorm(n*p), n, p)
-	W = rbinom(n, 1, 0.5)
-	Y = W * (X[,1] + X[,6]) + rnorm(n)
-	 
-	forest = causal_forest(X, Y, W)
-	split.freq = split_frequencies(forest, 10)
-
- 	expect_gt(sum(split.freq[,6]), 0)
+    n = 1000
+    p = 6
+    X = matrix(rnorm(n*p), n, p)
+    W = rbinom(n, 1, 0.5)
+    Y = W * (X[,1] + X[,6]) + rnorm(n)
+    
+    forest = causal_forest(X, Y, W, compute.oob.predictions = FALSE)
+    split.freq = split_frequencies(forest, 10)
+    
+    expect_gt(sum(split.freq[,6]), 0)
 })
 
 test_that("causal forests have reasonable split frequencies", {
-  n = 100
-  p = 7
-  X = matrix(rnorm(n*p), n, p)
-  W = rbinom(n, 1, 0.2)
-  Y = 1000 * (X[,p]) * (2 * W - 1) + rnorm(n)
-
-  # Note that we increase imbalance.penalty to ensure the test reliably passes. Once
-  # we add variance corrections, this should no longer be necessary.
-  ccc = causal_forest(X, Y, W, mtry = p, imbalance.penalty=0.1, stabilize.splits=TRUE, min.node.size=2)
-  split.freq = split_frequencies(ccc, 4)
-  expect_true(split.freq[1,p] / sum(split.freq[1,]) > 2/3)
+    n = 100
+    p = 7
+    X = matrix(rnorm(n*p), n, p)
+    W = rbinom(n, 1, 0.2)
+    Y = 1000 * (X[,p]) * (2 * W - 1) + rnorm(n)
+    
+    # Note that we increase imbalance.penalty to ensure the test reliably passes. Once
+    # we add variance corrections, this should no longer be necessary.
+    ccc = causal_forest(X, Y, W, mtry = p, imbalance.penalty=0.1, stabilize.splits=TRUE, min.node.size=2)
+    split.freq = split_frequencies(ccc, 4)
+    expect_true(split.freq[1,p] / sum(split.freq[1,]) > 2/3)
 })
 
 test_that("causal forests without stable splitting have reasonable split frequencies", {
-  n = 100
-  p = 7
-  X = matrix(rnorm(n*p), n, p)
-  W = rbinom(n, 1, 0.2)
-  Y = 1000 * (X[,p]) * (2 * W - 1) + rnorm(n)
-
-  # Note that we increase imbalance.penalty to ensure the test reliably passes. Once
-  # we add variance corrections, this should no longer be necessary.
-  ccc = causal_forest(X, Y, W, mtry = p, imbalance.penalty=0.1, stabilize.splits=FALSE, min.node.size=2)
-  split.freq = split_frequencies(ccc, 4)
-  expect_true(split.freq[1,p] / sum(split.freq[1,]) > 2/3)
+    n = 100
+    p = 7
+    X = matrix(rnorm(n*p), n, p)
+    W = rbinom(n, 1, 0.2)
+    Y = 1000 * (X[,p]) * (2 * W - 1) + rnorm(n)
+    
+    # Note that we increase imbalance.penalty to ensure the test reliably passes. Once
+    # we add variance corrections, this should no longer be necessary.
+    ccc = causal_forest(X, Y, W, mtry = p, imbalance.penalty=0.1, stabilize.splits=FALSE, min.node.size=2)
+    split.freq = split_frequencies(ccc, 4)
+    expect_true(split.freq[1,p] / sum(split.freq[1,]) > 2/3)
 })
 
 test_that("causal forests behave reasonably with a low treatment probability", {
-	n = 1000
-	p = 5
-
-	X = matrix(rnorm(n * p), n, p)
-	W = rbinom(n, 1, 0.1)
-	tau = 0.1
-	Y = X[,1] + X[,2] + tau * W + rnorm(n)
-
-	forest = causal_forest(X, Y, W, stabilize.splits = TRUE)
-	tau.hat = predict(forest)$predictions
-	expect_true(sqrt(mean((tau.hat - tau)^2)) < 0.20)
+    n = 1000
+    p = 5
+    
+    X = matrix(rnorm(n * p), n, p)
+    W = rbinom(n, 1, 0.1)
+    tau = 0.1
+    Y = X[,1] + X[,2] + tau * W + rnorm(n)
+    
+    forest = causal_forest(X, Y, W, stabilize.splits = TRUE)
+    tau.hat = predict(forest)$predictions
+    expect_true(sqrt(mean((tau.hat - tau)^2)) < 0.20)
 })
 
 test_that("causal forest tuning decreases prediction error", {
-	p = 4
-	n = 1000
-
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	W = rbinom(n, 1, 0.5)
-	TAU = 0.1 * (X[,1] > 0)
-	Y = TAU * (W  - 1/2) + 2 * rnorm(n)
-
-	forest = causal_forest(X, Y, W, num.trees = 400, min.node.size = 1, tune.parameters = FALSE)
-	preds = predict(forest)
-	error = mean((preds$predictions - TAU)^2)
-
-	tuned.forest = causal_forest(X, Y, W, num.trees = 400, tune.parameters = TRUE)
-	tuned.preds = predict(tuned.forest)
-	tuned.error = mean((tuned.preds$predictions - TAU)^2)
-
-	expect_true(tuned.error < error * 0.75)
+    p = 4
+    n = 1000
+    
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    W = rbinom(n, 1, 0.5)
+    TAU = 0.1 * (X[,1] > 0)
+    Y = TAU * (W  - 1/2) + 2 * rnorm(n)
+    
+    forest = causal_forest(X, Y, W, num.trees = 400, min.node.size = 1, tune.parameters = FALSE)
+    preds = predict(forest)
+    error = mean((preds$predictions - TAU)^2)
+    
+    tuned.forest = causal_forest(X, Y, W, num.trees = 400, tune.parameters = TRUE)
+    tuned.preds = predict(tuned.forest)
+    tuned.error = mean((tuned.preds$predictions - TAU)^2)
+    
+    expect_true(tuned.error < error * 0.75)
 })
 
 test_that("causal forest tuning only cross-validates null parameters", {
-	p = 6
-	n = 100
-
-	X = matrix(2 * runif(n * p) - 1, n, p)
-	W = rbinom(n, 1, 0.5)
-	TAU = 2 * (X[,1] > 0)
-	Y = TAU * (W  - 1/2) + 2 * rnorm(n)
-
-	min.node.size = 5
-	imbalance.penalty = 0.42
-
-  tune.output = tune_causal_forest(X, Y, W, min.node.size = min.node.size, imbalance.penalty = imbalance.penalty)
-  tunable.params = tune.output$params
-
-  expect_equal(as.numeric(tunable.params["min.node.size"]), min.node.size)
-  expect_equal(as.numeric(tunable.params["imbalance.penalty"]), imbalance.penalty)
+    p = 6
+    n = 100
+    
+    X = matrix(2 * runif(n * p) - 1, n, p)
+    W = rbinom(n, 1, 0.5)
+    TAU = 2 * (X[,1] > 0)
+    Y = TAU * (W  - 1/2) + 2 * rnorm(n)
+    
+    min.node.size = 5
+    imbalance.penalty = 0.42
+    
+    tune.output = tune_causal_forest(X, Y, W, min.node.size = min.node.size, imbalance.penalty = imbalance.penalty)
+    tunable.params = tune.output$params
+    
+    expect_equal(as.numeric(tunable.params["min.node.size"]), min.node.size)
+    expect_equal(as.numeric(tunable.params["imbalance.penalty"]), imbalance.penalty)
 })
 
 test_that("causal forests behave reasonably with small sample size", {
-  p = 5
-  n = 50
-  X = matrix(rnorm(n * p), n, p)
-  W = rbinom(n, 1, 0.5)
-  tau = 100 * (X[,1] > 0)
-  Y = tau * (W - 0.5) + rnorm(n)
-  forest = causal_forest(X, Y, W, stabilize.splits = TRUE, min.node.size = 1, mtry = p)
-  tau.hat = predict(forest)$predictions
-  expect_true(sqrt(mean((tau.hat - tau)^2)) / 100 < 1/4)
+    p = 5
+    n = 50
+    X = matrix(rnorm(n * p), n, p)
+    W = rbinom(n, 1, 0.5)
+    tau = 100 * (X[,1] > 0)
+    Y = tau * (W - 0.5) + rnorm(n)
+    forest = causal_forest(X, Y, W, stabilize.splits = TRUE,
+                           min.node.size = 1, mtry = p,
+                           compute.oob.predictions = FALSE)
+    
+    X.test = matrix(rnorm(n * p), n, p)
+    tau.test = 100 * (X.test[,1] > 0)
+    tau.hat = predict(forest, X.test)$predictions
+    expect_true(sqrt(mean((tau.hat - tau.test)^2)) / 100 < 1/3)
 })

--- a/r-package/grf/tests/testthat/test_regression_forest.R
+++ b/r-package/grf/tests/testthat/test_regression_forest.R
@@ -68,7 +68,7 @@ test_that("OOB predictions contain debiased error estimates", {
 	forest = regression_forest(X, Y, num.trees = 1000, ci.group.size = 4)
 	preds.oob = predict(forest)
 
-	expect_equal(n, nrow(preds.oob$debiased.error))
+	expect_equal(n, length(preds.oob$debiased.error))
 })
 
 test_that("regression forest tuning decreases prediction error", {


### PR DESCRIPTION
Most grf workflows involve computing OOB predictions on the training set. The current implementation doesn't cache these predictions, resulting in needless repeat computation. To avoid this, we now simply make OOB predictions by default during training, so that they are immediately available whenever needed.

Addresses a point discussed in #238 